### PR TITLE
fix initial value issue

### DIFF
--- a/js/jquery.ThreeDots.js
+++ b/js/jquery.ThreeDots.js
@@ -286,7 +286,7 @@
 				var nr_fixed = num_rows(curr_this, true);
 
 				// remember where it all began so that we can see if we ended up exactly where we started
-				var init_text_span = $(curr_text_span).text();
+				var init_text_span = ($(curr_this).attr('threedots') === undefined)? $(curr_text_span).text() : $(curr_this).attr('threedots');
 
 				// preprocessor
 				the_bisector(curr_this, curr_text_span, nr_fixed);


### PR DESCRIPTION
The element has a text like:
"My very long lorem ipsum text that goes on multiple lines"
On resolutions of 767 and up I want it to display on max 3 rows and on lower resolutions I want it to display a max of 6 rows.

My setup is like this:
```
var threeDotsInit;
var rtime;
var resizeTimeout = false;
var delta = 250;
function resizeEnd() {
    if (new Date() - rtime < delta) {
        setTimeout(resizeEnd, delta);
    } else {
        resizeTimeout = false;
        threeDotsInit.ThreeDots.update({
            max_rows: (windowWidth > 480)? 3 : 0,
            alt_text_t: true,
            ellipsis_string: " ..."
        });
    }
}
$(document).ready(function(){
    threeDotsInit = $('.product-title').ThreeDots({
        max_rows: (windowWidth > 480)? 3 : 0,
        alt_text_t: true,
        ellipsis_string: " ..."
    });
});

$(window).resize(function() {
    rtime = new Date();
    if (resizeTimeout === false) {
        resizeTimeout = true;
        setTimeout(resizeEnd, delta);
    }
});
```

This resulted in the following:
1. Init: 
`<a href="https://google.com" class="product-title" threedots="My very long lorem ipsum text that goes on multiple lines"><span class="ellipsis_text" title="My very long lorem ipsum text that goes on multiple lines">My very long lorem ipsum text that</span><span style="white-space: nowrap; display: inline;" class="threedots_ellipsis"> ...</span></a>` - At this point it is ok

2. resize - that means reinit because of the update function
`<a href="https://google.com" class="product-title" threedots="My very long lorem ipsum text that"><span class="ellipsis_text" title="My very long lorem ipsum text that">My very long lorem ipsum text that</a>`

It was basically rewriting `init_text_span` with the actual value in the `$(curr_text_span).text()` which was not correct after 1 resize.

So I added another check that only rewrites the init_text_span if the 'threedots' attribute is not initialized and it fixed my issues.
